### PR TITLE
feat: Support AnimatedJava 1.10.x for Blockbench 5

### DIFF
--- a/src/main/java/de/tomalbrc/bil/file/bbmodel/BbFace.java
+++ b/src/main/java/de/tomalbrc/bil/file/bbmodel/BbFace.java
@@ -1,10 +1,13 @@
 package de.tomalbrc.bil.file.bbmodel;
 
+import com.mojang.datafixers.util.Either;
+
 import java.util.List;
+import java.util.UUID;
 
 public class BbFace {
     public List<Float> uv;
-    public Integer texture;
+    public Either<Integer, UUID> texture;
     public int tintindex = 0;
 
     public int rotation;

--- a/src/main/java/de/tomalbrc/bil/file/extra/ResourcePackModel.java
+++ b/src/main/java/de/tomalbrc/bil/file/extra/ResourcePackModel.java
@@ -3,9 +3,9 @@ package de.tomalbrc.bil.file.extra;
 import de.tomalbrc.bil.file.bbmodel.BbElement;
 import de.tomalbrc.bil.file.bbmodel.BbFace;
 import de.tomalbrc.bil.file.bbmodel.BbTexture;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.resources.Identifier;
 import org.apache.commons.io.FilenameUtils;
 import org.joml.Vector3f;
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 public class ResourcePackModel {
     public static ResourcePackModel.DisplayTransform DEFAULT_TRANSFORM = new ResourcePackModel.DisplayTransform(new Vector3f(0, 180, 0), null, null); // default BIL model transform
@@ -57,15 +58,15 @@ public class ResourcePackModel {
             return this;
         }
 
-        public Builder withTextures(Int2ObjectOpenHashMap<BbTexture> intTextureMap) {
+        public Builder withTextures(Object2ObjectOpenHashMap<?, BbTexture> intTextureMap) {
             this.textureMap = new Object2ObjectLinkedOpenHashMap<>();
             if (intTextureMap != null) {
-                for (var entry : intTextureMap.int2ObjectEntrySet()) {
+                for (var entry : intTextureMap.entrySet()) {
                     var str = FilenameUtils.getBaseName(entry.getValue().name.toLowerCase());
                     while (str.endsWith(".png")) { // remove all .png extensions if multiple
                         str = str.substring(0, str.length() - 4);
                     }
-                    this.textureMap.put(String.valueOf(entry.getIntKey()), Identifier.fromNamespaceAndPath("bil", "item/" + this.modelId + "/" + str));
+                    this.textureMap.put(String.valueOf(entry.getKey()), Identifier.fromNamespaceAndPath("bil", "item/" + this.modelId + "/" + str));
                 }
             }
             return this;
@@ -87,8 +88,8 @@ public class ResourcePackModel {
             if (this.elements != null)
                 for (BbElement element : this.elements) {
                     for (Map.Entry<String, BbFace> bbFaceEntry : element.faces.entrySet()) {
-                        String n = String.valueOf(bbFaceEntry.getValue().texture);
-                        optimizedTextureMap.put(n, this.textureMap.get(n));
+                        String id = String.valueOf(bbFaceEntry.getValue().texture.map(Object::toString, UUID::toString));
+                        optimizedTextureMap.put(id, this.textureMap.get(id));
                     }
                 }
             return new ResourcePackModel(this.parent, optimizedTextureMap, this.elements, this.transformMap);

--- a/src/main/java/de/tomalbrc/bil/file/importer/AjBlueprintImporter.java
+++ b/src/main/java/de/tomalbrc/bil/file/importer/AjBlueprintImporter.java
@@ -11,7 +11,8 @@ import de.tomalbrc.bil.json.CachedUuidDeserializer;
 import de.tomalbrc.bil.util.VersionCheck;
 import de.tomalbrc.bil.util.command.CommandParser;
 import de.tomalbrc.bil.util.command.ParsedCommand;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import net.minecraft.resources.Identifier;
@@ -67,13 +68,13 @@ public class AjBlueprintImporter extends AjModelImporter implements ModelImporte
                     if (!outliner.isHitbox() && affected) {
                         List<BbElement> elements = BbModelUtils.elementsForOutliner(model, outliner, BbElement.ElementType.CUBE_MODEL);
 
-                        Int2ObjectOpenHashMap<BbTexture> textureMap = new Int2ObjectOpenHashMap<>();
+                        Object2ObjectOpenHashMap<UUID, BbTexture> textureMap = new Object2ObjectOpenHashMap<>();
                         if (variant.textureMap() == null || variant.textureMap().isEmpty()) {
-                            textureMap = makeDefaultTextureMap();
+                            textureMap = makeDefaultUuidTextureMap();
                         } else {
                             for (BbTexture e : model.textures) {
                                 BbTexture newMapped = variant.textureMap().containsKey(e.uuid) ? BbModelUtils.getTexture(model, variant.textureMap().get(e.uuid)) : e;
-                                textureMap.putIfAbsent(e.id, newMapped);
+                                textureMap.putIfAbsent(e.uuid, newMapped);
                             }
                         }
 
@@ -137,5 +138,19 @@ public class AjBlueprintImporter extends AjModelImporter implements ModelImporte
     @Override
     protected boolean flipAnimationX() {
         return !VersionCheck.isAtLeastVersion(model.meta.formatVersion, "1.10.1");
+    }
+
+    @Override
+    protected Object2ObjectOpenHashMap<?, BbTexture> makeDefaultTextureMap() {
+        return makeDefaultUuidTextureMap();
+    }
+
+    protected Object2ObjectOpenHashMap<UUID, BbTexture> makeDefaultUuidTextureMap() {
+        Object2ObjectOpenHashMap<UUID, BbTexture> textureMap = new Object2ObjectOpenHashMap<>();
+        ObjectArrayList<BbTexture> textures = model.textures;
+        for (BbTexture texture : textures) {
+            textureMap.put(texture.uuid, texture);
+        }
+        return textureMap;
     }
 }

--- a/src/main/java/de/tomalbrc/bil/file/importer/AjBlueprintImporter.java
+++ b/src/main/java/de/tomalbrc/bil/file/importer/AjBlueprintImporter.java
@@ -8,6 +8,7 @@ import de.tomalbrc.bil.file.extra.BbModelUtils;
 import de.tomalbrc.bil.file.extra.BbResourcePackGenerator;
 import de.tomalbrc.bil.file.extra.ResourcePackModel;
 import de.tomalbrc.bil.json.CachedUuidDeserializer;
+import de.tomalbrc.bil.util.VersionCheck;
 import de.tomalbrc.bil.util.command.CommandParser;
 import de.tomalbrc.bil.util.command.ParsedCommand;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
@@ -116,18 +117,25 @@ public class AjBlueprintImporter extends AjModelImporter implements ModelImporte
         UUID effectsUUID = CachedUuidDeserializer.get("effects");
         if (effectsUUID != null && anim.animators != null && anim.animators.containsKey(effectsUUID) && anim.animators.get(effectsUUID).type == BbAnimator.Type.EFFECT) {
             BbAnimator animator = anim.animators.get(effectsUUID);
-            if (animator.keyframes != null) for (BbKeyframe kf : animator.keyframes) {
-                float difference = Mth.ceil(kf.time / 0.05f) * 0.05f; // snap value to 50ms increments
-                if (difference == t && kf.channel == BbKeyframe.Channel.COMMANDS) {
-                    var script = kf.dataPoints.getFirst().get("commands").getStringValue();
-                    if (!script.isEmpty()) {
-                        ParsedCommand[] cmds = CommandParser.parse(kf.dataPoints.getFirst().get("commands").getStringValue());
-                        ParsedCommand[] cond = kf.dataPoints.getFirst().containsKey("execute_condition") ? CommandParser.parse(kf.dataPoints.getFirst().get("execute_condition").getStringValue()) : null;
-                        return new Frame.Commands(cmds, cond);
+            if (animator.keyframes != null) {
+                for (BbKeyframe kf : animator.keyframes) {
+                    float difference = Mth.ceil(kf.time / 0.05f) * 0.05f; // snap value to 50ms increments
+                    if (difference == t && kf.channel == BbKeyframe.Channel.COMMANDS) {
+                        var script = kf.dataPoints.getFirst().get("commands").getStringValue();
+                        if (!script.isEmpty()) {
+                            ParsedCommand[] cmds = CommandParser.parse(kf.dataPoints.getFirst().get("commands").getStringValue());
+                            ParsedCommand[] cond = kf.dataPoints.getFirst().containsKey("execute_condition") ? CommandParser.parse(kf.dataPoints.getFirst().get("execute_condition").getStringValue()) : null;
+                            return new Frame.Commands(cmds, cond);
+                        }
                     }
                 }
             }
         }
         return null;
+    }
+
+    @Override
+    protected boolean flipAnimationX() {
+        return !VersionCheck.isAtLeastVersion(model.meta.formatVersion, "1.10.1");
     }
 }

--- a/src/main/java/de/tomalbrc/bil/file/importer/AjModelImporter.java
+++ b/src/main/java/de/tomalbrc/bil/file/importer/AjModelImporter.java
@@ -10,7 +10,7 @@ import de.tomalbrc.bil.file.extra.ResourcePackModel;
 import de.tomalbrc.bil.json.CachedUuidDeserializer;
 import de.tomalbrc.bil.util.command.CommandParser;
 import de.tomalbrc.bil.util.command.ParsedCommand;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
 import net.minecraft.resources.Identifier;
@@ -21,7 +21,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.UUID;
 
-public class AjModelImporter extends BbModelImporter implements ModelImporter<BbModel> {
+public class AjModelImporter extends BbModel5Importer implements ModelImporter<BbModel> {
     public AjModelImporter(BbModel model) {
         super(model);
     }
@@ -58,9 +58,9 @@ public class AjModelImporter extends BbModelImporter implements ModelImporter<Bb
                     if (!outliner.isHitbox() && affected) {
                         List<BbElement> elements = BbModelUtils.elementsForOutliner(model, outliner, BbElement.ElementType.CUBE_MODEL);
 
-                        Int2ObjectOpenHashMap<BbTexture> textureMap = new Int2ObjectOpenHashMap<>();
+                        Object2ObjectOpenHashMap<Integer, BbTexture> textureMap = new Object2ObjectOpenHashMap<>();
                         if (variant.textureMap() == null || variant.textureMap().isEmpty()) {
-                            textureMap = makeDefaultTextureMap();
+                            textureMap = makeDefaultIntTextureMap();
                         } else {
                             for (BbTexture e : model.textures) {
                                 BbTexture newMapped = variant.textureMap().containsKey(e.uuid) ? BbModelUtils.getTexture(model, variant.textureMap().get(e.uuid)) : e;

--- a/src/main/java/de/tomalbrc/bil/file/importer/BbModelImporter.java
+++ b/src/main/java/de/tomalbrc/bil/file/importer/BbModelImporter.java
@@ -42,7 +42,7 @@ public class BbModelImporter implements ModelImporter<BbModel> {
             BbFace face = entry.getValue();
             for (int i = 0; i < face.uv.size(); i++) {
                 Vector2i textureResolution = null;
-                var texture = textures.get(face.texture);
+                var texture = textures.get(face.texture.left().orElseThrow());
                 if (texture.uvHeight != 0 && texture.uvWidth != 0)
                     textureResolution = new Vector2i(texture.uvWidth, texture.uvHeight);
 
@@ -315,7 +315,7 @@ public class BbModelImporter implements ModelImporter<BbModel> {
                         Sampler.sample(animator.keyframes, model.animationVariablePlaceholders, environment, time);
 
                 Quaternionf localRot = Utils.createQuaternion(triple.getMiddle().mul(-1, -1, 1).add(node.transform().rotation()));
-                Vector3f localPos = triple.getLeft().mul(-1, 1, 1).div(16).add(origin);
+                Vector3f localPos = triple.getLeft().mul(flipAnimationX() ? -1 : 1, 1, 1).div(16).add(origin);
 
                 matrix4f.translate(localPos);
                 matrix4f.rotate(localRot);
@@ -326,6 +326,10 @@ public class BbModelImporter implements ModelImporter<BbModel> {
             poses.put(entry.getKey(), Pose.of(matrix4f.scale(entry.getValue().transform().localScale())));
         }
         return poses;
+    }
+
+    protected boolean flipAnimationX() {
+        return true;
     }
 
     @Nullable

--- a/src/main/java/de/tomalbrc/bil/file/importer/BbModelImporter.java
+++ b/src/main/java/de/tomalbrc/bil/file/importer/BbModelImporter.java
@@ -11,7 +11,6 @@ import de.tomalbrc.bil.util.command.CommandParser;
 import gg.moonflower.molangcompiler.api.MolangEnvironment;
 import gg.moonflower.molangcompiler.api.MolangRuntime;
 import gg.moonflower.molangcompiler.api.exception.MolangRuntimeException;
-import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.objects.*;
 import net.minecraft.resources.Identifier;
 import net.minecraft.sounds.SoundEvent;
@@ -441,8 +440,12 @@ public class BbModelImporter implements ModelImporter<BbModel> {
         return res;
     }
 
-    protected Int2ObjectOpenHashMap<BbTexture> makeDefaultTextureMap() {
-        Int2ObjectOpenHashMap<BbTexture> textureMap = new Int2ObjectOpenHashMap<>();
+    protected Object2ObjectOpenHashMap<?, BbTexture> makeDefaultTextureMap() {
+        return makeDefaultIntTextureMap();
+    }
+
+    protected Object2ObjectOpenHashMap<Integer, BbTexture> makeDefaultIntTextureMap() {
+        Object2ObjectOpenHashMap<Integer, BbTexture> textureMap = new Object2ObjectOpenHashMap<>();
         ObjectArrayList<BbTexture> textures = model.textures;
         for (int i = 0, texturesSize = textures.size(); i < texturesSize; i++) {
             BbTexture texture = textures.get(i);

--- a/src/main/java/de/tomalbrc/bil/json/FaceSerializer.java
+++ b/src/main/java/de/tomalbrc/bil/json/FaceSerializer.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonSerializer;
 import de.tomalbrc.bil.file.bbmodel.BbFace;
 
 import java.lang.reflect.Type;
+import java.util.UUID;
 
 public class FaceSerializer implements JsonSerializer<BbFace> {
     @Override
@@ -14,7 +15,7 @@ public class FaceSerializer implements JsonSerializer<BbFace> {
                                  JsonSerializationContext context) {
 
         JsonObject obj = new JsonObject();
-        obj.addProperty("texture", String.format("#%d", src.texture));
+        obj.addProperty("texture", src.texture.map(i -> String.format("#%d", i), UUID::toString));
         if (src.cullface != null) obj.addProperty("cullface", src.cullface);
         obj.addProperty("tintindex", src.tintindex);
         if (src.rotation != 0) obj.addProperty("rotation", src.rotation);

--- a/src/main/java/de/tomalbrc/bil/json/JSON.java
+++ b/src/main/java/de/tomalbrc/bil/json/JSON.java
@@ -2,7 +2,8 @@ package de.tomalbrc.bil.json;
 
 import com.google.gson.GsonBuilder;
 import com.mojang.datafixers.util.Either;
-import com.mojang.serialization.Codec;
+import com.mojang.datafixers.util.Pair;
+import com.mojang.serialization.*;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
@@ -10,7 +11,10 @@ import net.minecraft.sounds.SoundEvent;
 import net.minecraft.util.ExtraCodecs;
 import net.minecraft.util.Util;
 import net.minecraft.world.item.Item;
-import org.joml.*;
+import org.joml.Matrix4fc;
+import org.joml.Vector2i;
+import org.joml.Vector2ic;
+import org.joml.Vector3fc;
 
 import java.util.List;
 import java.util.UUID;
@@ -31,6 +35,22 @@ public class JSON {
                     Either::left
             );
 
+    public static final Codec<Either<Integer, UUID>> EITHER_INT_UUID = Codec.of(new Encoder<>() {
+        @Override
+        public <T> DataResult<T> encode(Either<Integer, UUID> input, DynamicOps<T> ops, T prefix) {
+            return DataResult.success(input.map(ops::createInt, u -> ops.createString(u.toString())));
+        }
+    }, new Decoder<>() {
+        @Override
+        public <T> DataResult<Pair<Either<Integer, UUID>, T>> decode(DynamicOps<T> ops, T input) {
+            DataResult<Number> result = ops.getNumberValue(input);
+            if (result.isError()) {
+                return DataResult.success(Pair.of(Either.right(UUID.fromString(ops.getStringValue(input).getOrThrow())), ops.empty()));
+            }
+            return DataResult.success(Pair.of(Either.left(result.getOrThrow().intValue()), ops.empty()));
+        }
+    });
+
     public static final GsonBuilder GENERIC_BUILDER = new GsonBuilder()
             // Reference equality
             .registerTypeHierarchyAdapter(UUID.class, new CachedUuidDeserializer())
@@ -40,5 +60,6 @@ public class JSON {
             .registerTypeHierarchyAdapter(Vector2ic.class, new SimpleCodecDeserializer<>(VECTOR2I))
             .registerTypeHierarchyAdapter(Identifier.class, new SimpleCodecDeserializer<>(Identifier.CODEC))
             .registerTypeHierarchyAdapter(Item.class, new RegistryDeserializer<>(BuiltInRegistries.ITEM))
-            .registerTypeHierarchyAdapter(SoundEvent.class, new RegistryDeserializer<>(BuiltInRegistries.SOUND_EVENT));
+            .registerTypeHierarchyAdapter(SoundEvent.class, new RegistryDeserializer<>(BuiltInRegistries.SOUND_EVENT))
+            .registerTypeHierarchyAdapter(Either.class, new SimpleCodecDeserializer<>(EITHER_INT_UUID));
 }


### PR DESCRIPTION
Fixes #12, this uses tomalbrc's patch from the Discord server (was left mostly untouched) and on top of that modifies the importer to be able to identify textures by UUID.
This implementation currently breaks compatiblity for AJ 1.8.x `ajblueprint`s and probably every `ajmodel`, as `AjModelImporter` is now a `BbModel5Importer`, I can look into fixing that if you want. Outdated Blockbench 4 models (without AJ) still work.
I have not tested models with variants so you may want to check if those are broken.